### PR TITLE
fix: remove type module

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,5 @@
   "files": [
     "bin/",
     "src/"
-  ],
-  "type": "module"
+  ]
 }


### PR DESCRIPTION
Since Node 14 you cannot use `require` when type is defined as module.