### PR TITLE
feat(splitter): spilt the test cases based on the execution time [DS-1145]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xislamtaha/orchestrator",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "orchestrate cypress parallel execution across multiple Docker containers",
   "main": "src/orchestrator.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -9,48 +9,35 @@ Orchestrator executes all cypress specs across n parallel docker containers base
 2- [Cypress parallelization with the Orchestrator — part 2 — ShowCase](https://0xislamtaha.medium.com/cypress-parallelization-with-the-orchestrator-part-2-showcase-c78202b17c7a)
 
 ## 😍 Usecases:
+Check the following repo as a public use case.
 - [Orchestrator-Public-Use-Case](https://github.com/0xIslamTaha/orchestrator-public-use-case)
 
 ## ♟️ Orchestrator mechanism:
 
-* Pares a config file 
-* Create n containers machines  in parallel
-* Split all specs across all those machines 
-* Collect all the execution results from those containers 
-* Down all the running containers
-* Generate one HTML report that has all specs execution results
+* Pares a config file.
+* Create (config.parallelizm * config.browsers.length) containers in parallel.
+* Split all specs across all those machines based on their execution time.
+* Collect all the execution results from those containers.
+* Down all the running containers.
+* Generate one HTML report that has all specs execution results.
+* Analyse the execution time for each spec.
+* If you fed the orchestrator with this execution time JSON file, It will split the test cases based on that.
 
-## Features:
-- Create n chrome containers and/or n firefox containers
-- Split the spcecs accross those continers
-- Manage the results
-- Generate HTML report
+## 🏹 The Splitting mechanism:
+The orchestrator can measure and report the execution time for each spec per browser. It will report it as `mochawesome-report/specsExecutionTime-chrome.json` file. If you provided this path as `specsExecutionTimePath`  in the next run, The orchestrator will split the specs based on its execution time to minimize the total execution time 🚀. 
 
 ## 👌 Installation:
-
+* Install from npm
 ```bash
 npm -g install 0xislamtaha/orchestrator
 ```
 
-## 🎮 Usage:
-
-* With the default configuration file i.e, "src/config.json"
+* Install from Github branch
 ```bash
-orchestrator
+npm -g install @0xislamtaha/orchestrator:development
 ```
 
-* With your configuration file
-```bash
-orchestrator --config "/path/to/config.json"
-```
-
-If you need to **overwrite** any configuration on the fly, simplly path the new configuration as a prameter.
-```bash
-orchestrator --config ./src/config.json --parallelizm 2 --environment '{"DOCKER_TAG":"master_283"}' --browsers "[chrome, firefox]"
-```
-
-
-## 🔑 Requirements to use orchrestrator:
+## 🔑 Requirements to use orchestrator:
 1- docker-compose file with a cypress service. here is an example of it.
 
 ```yml
@@ -58,14 +45,14 @@ orchestrator --config ./src/config.json --parallelizm 2 --environment '{"DOCKER_
 version: '3.8'
 services:
   cypress-container:
-    build: ./
+    image: 0xislamtaha/cypress-snapshot-image:latest
     network_mode: "bridge"
     volumes:
-      - ./cypress/:/orechestrator_usecase/cypress
-      - ./mochawesome-report:/orechestrator_usecase/mochawesome-report
+      - ./cypress/:/cypress_testing/cypress
+      - ./mochawesome-report:/cypress_testing/mochawesome-report
       - /dev/shm:/dev/shm
 ```
-2- use mochawsome as a reporter in cypress.json, just add the following snippet to your cypress.json.
+2- use mochawesome as a reporter in cypress.json, just add the following snippet to your cypress.json.
 
 ```json
 {
@@ -142,10 +129,31 @@ services:
     type: array
     example: ["test.js", "test2.js"]
 
+- analyseReport:
+    description: boolen value to generate an execution time report. 
+    type: boolen
+    example: true
+
+- specsExecutionTimePath:
+    description: path to the execution time file.
+    type: string
+    example: "mochawesome-report/specsExecutionTime-chrome.json"
+
+```
+
+## 🎮 Usage:
+
+* With your configuration file
+```bash
+npx orchestrator --config "/path/to/config.json"
+```
+
+* You can **overwrite** any configuration param on the fly, simplly path the new configuration as a prameter.
+```bash
+npx orchestrator --config ./src/config.json --parallelizm 2 --environment '{"DOCKER_TAG":"master_283"}' --browsers "[chrome, firefox]" --specs "[alerts.js, avatar.js]"
 ```
 
 ## 🎬 To-Do:
-* Export COMPOSE_PROJECT_NAME with random value if it doesnt exist.
-* Print the commands.
-* list configuration rather than multiple files.
+* Export COMPOSE_PROJECT_NAME with random value if it doesn't exist.
+* list configuration rather than multiple files for multiple test suites.
 * Provide --help option.

--- a/src/analyseReport.js
+++ b/src/analyseReport.js
@@ -51,6 +51,13 @@ function checkReportIsExisting(reportPath) {
   }
 }
 
+function millisToMinutesAndSeconds(millis) {
+  let minutes = Math.floor(millis / 60000);
+  let seconds = ((millis % 60000) / 1000).toFixed(0);
+  return `${minutes}:${(seconds < 10 ? '0' : '')}${ seconds}`;
+}
+
+
 export function analyseReport(reportPath) {
   console.log("analyse the json report .... ");
 
@@ -72,7 +79,7 @@ export function analyseReport(reportPath) {
       console.table(
         orderBasedOnBrowserDuration(browser).map(spec => { return {
           specName: spec.specName,
-          duration: spec.data.find( item => item.browser === browser ).duration
+          duration: millisToMinutesAndSeconds(spec.data.find( item => item.browser === browser ).duration)
         } })
       );
     }

--- a/src/analyseReport.js
+++ b/src/analyseReport.js
@@ -6,13 +6,15 @@ import {
   millisToMinutesAndSeconds,
   writeJsonFile,
 } from "./helper.js";
+import path from "path";
+
 
 const browsers = ["chrome", "firefox"];
 const defaultBrowser = "chrome"; // I will use it in case of there is no browser in the title.
 const specs = [];
 
 function getBrowserFromTitle(title) {
-  return browsers.find((browser) => title.toLowerCase().includes(browser));
+  return browsers.find((browser) => title.toLowerCase() === browser);
 }
 
 function intiateSpecData(specName) {
@@ -44,7 +46,7 @@ export function analyseReport(mochaReportPath) {
   console.log("analyse the json report .... ");
 
   if (checkFileIsExisting(mochaReportPath)) {
-    const reportDir = mochaReportPath.substring(0, mochaReportPath.lastIndexOf("/"));
+    const reportDir = path.dirname(mochaReportPath);
     const report = require(mochaReportPath);
 
     report["results"].forEach( result => {

--- a/src/analyseReport.js
+++ b/src/analyseReport.js
@@ -67,7 +67,7 @@ export function analyseReport(mochaReportPath) {
           ),
         };
       });
-      writeJsonFile(data, reportDir, `SpecsExecutionTime-${browser}.json`);
+      writeJsonFile(data, reportDir, `specsExecutionTime-${browser}.json`);
       console.table(data);
     }
   }

--- a/src/analyseReport.js
+++ b/src/analyseReport.js
@@ -1,22 +1,15 @@
-const fs = require("fs");
-let specs = [];
+import { checkFileIsExisting, orderBasedOnBrowserDuration, millisToMinutesAndSeconds } from "./helper.js";
+
 const browsers = ["chrome", "firefox"];
 const defaultBrowser = "chrome"; // I will use it in case of there is no browser in the title.
+const specs = [];
 
 function getBrowserFromTitle(title) {
-  return browsers.find(browser => title.toLowerCase().includes(browser))
-}
-
-function orderBasedOnBrowserDuration(browser) {
-  return specs.sort(function (a, b) {
-    let aDuration = a.data.find( item => item.browser === browser ).duration
-    let bDuration = b.data.find( item => item.browser === browser ).duration
-    return aDuration - bDuration;
-  });
+  return browsers.find((browser) => title.toLowerCase().includes(browser));
 }
 
 function intiateSpecData(specName) {
-  if (!specs.find( spec => spec.specName === specName )) {
+  if (!specs.find((spec) => spec.specName === specName)) {
     specs.push({
       specName: specName,
       data: browsers.map((browser) => {
@@ -27,41 +20,23 @@ function intiateSpecData(specName) {
 }
 
 function updateSpecData(suites, specName) {
-  suites.forEach(suite => {
+  suites.forEach((suite) => {
     let browser = getBrowserFromTitle(suite["title"]) || defaultBrowser;
     let duration = parseInt(suite["duration"]);
 
-    let spec = specs.find( spec => spec.specName === specName );
-    if (spec) spec.data.find( item => item.browser === browser ).duration += duration;
+    let spec = specs.find((spec) => spec.specName === specName);
+    if (spec)
+      spec.data.find((item) => item.browser === browser).duration += duration;
     if (suite.hasOwnProperty("suites")) {
       updateSpecData(suite.suites, specName);
     }
-  })
+  });
 }
-
-function checkReportIsExisting(reportPath) {
-  let path = reportPath;
-  if (fs.existsSync(path)) {
-    return true;
-  } else {
-    console.log(
-      `report does not exist, are you sure there is a json report in ${path} path?`
-    );
-    return false;
-  }
-}
-
-function millisToMinutesAndSeconds(millis) {
-  let minutes = Math.floor(millis / 60000);
-  let seconds = ((millis % 60000) / 1000).toFixed(0);
-  return `${minutes}:${(seconds < 10 ? '0' : '')}${ seconds}`;
-}
-
 
 export function analyseReport(reportPath) {
   console.log("analyse the json report .... ");
 
-  if (checkReportIsExisting(reportPath)) {
+  if (checkFileIsExisting(reportPath)) {
     const report = require(reportPath);
 
     report["results"].forEach(function (result) {
@@ -77,10 +52,14 @@ export function analyseReport(reportPath) {
         `------------------------- ${browser} -------------------------`
       );
       console.table(
-        orderBasedOnBrowserDuration(browser).map(spec => { return {
-          specName: spec.specName,
-          duration: millisToMinutesAndSeconds(spec.data.find( item => item.browser === browser ).duration)
-        } })
+        orderBasedOnBrowserDuration(specs, browser).map((spec) => {
+          return {
+            specName: spec.specName,
+            duration: millisToMinutesAndSeconds(
+              spec.data.find((item) => item.browser === browser).duration
+            ),
+          };
+        })
       );
     }
   }

--- a/src/analyseReport.js
+++ b/src/analyseReport.js
@@ -1,4 +1,11 @@
-import { checkFileIsExisting, orderBasedOnBrowserDuration, millisToMinutesAndSeconds } from "./helper.js";
+//@ts-check
+
+import {
+  checkFileIsExisting,
+  orderBasedOnBrowserDuration,
+  millisToMinutesAndSeconds,
+  writeJsonFile,
+} from "./helper.js";
 
 const browsers = ["chrome", "firefox"];
 const defaultBrowser = "chrome"; // I will use it in case of there is no browser in the title.
@@ -33,13 +40,14 @@ function updateSpecData(suites, specName) {
   });
 }
 
-export function analyseReport(reportPath) {
+export function analyseReport(mochaReportPath) {
   console.log("analyse the json report .... ");
 
-  if (checkFileIsExisting(reportPath)) {
-    const report = require(reportPath);
+  if (checkFileIsExisting(mochaReportPath)) {
+    const reportDir = mochaReportPath.substring(0, mochaReportPath.lastIndexOf("/"));
+    const report = require(mochaReportPath);
 
-    report["results"].forEach(function (result) {
+    report["results"].forEach( result => {
       let specFile = result["file"].split("/").pop();
       let suites = result["suites"];
 
@@ -51,16 +59,16 @@ export function analyseReport(reportPath) {
       console.log(
         `------------------------- ${browser} -------------------------`
       );
-      console.table(
-        orderBasedOnBrowserDuration(specs, browser).map((spec) => {
-          return {
-            specName: spec.specName,
-            duration: millisToMinutesAndSeconds(
-              spec.data.find((item) => item.browser === browser).duration
-            ),
-          };
-        })
-      );
+      let data = orderBasedOnBrowserDuration(specs, browser).map((spec) => {
+        return {
+          specName: spec.specName,
+          duration: millisToMinutesAndSeconds(
+            spec.data.find((item) => item.browser === browser).duration
+          ),
+        };
+      });
+      writeJsonFile(data, reportDir, `SpecsExecutionTime-${browser}.json`);
+      console.table(data);
     }
   }
 }

--- a/src/config.json
+++ b/src/config.json
@@ -13,7 +13,7 @@
   "specsDockerPath": "tests/cypress/storybook/",
   "cypressContainerName": "cypress_container",
   "mochawesomeJSONPath": "/opt/code/github/design-system/tests/report/mochawesome-report/*.json",
-  "reportPath": "./",
+  "reportPath": "mochawesome-report",
   "specs": [],
   "analyseReport": false,
   "specsExecutionTimePath": "tests/specExecutionTime.json"

--- a/src/config.json
+++ b/src/config.json
@@ -16,5 +16,5 @@
   "reportPath": "mochawesome-report",
   "specs": [],
   "analyseReport": false,
-  "specsExecutionTimePath": "tests/specExecutionTime.json"
+  "specsExecutionTimePath": "mochawesome-report/specsExecutionTime-chrome.json"
 }

--- a/src/config.json
+++ b/src/config.json
@@ -6,14 +6,15 @@
     "DOCKER_TAG": "master_283"
   },
   "preCommands": [
-    "docker-compose -f /opt/code/github/cloud-fe-components/cypress.docker-compose.yml up -d cloud_fe_components"
+    "docker-compose -f /opt/code/github/design-system/cypress.docker-compose.yml up -d cloud_fe_components"
   ],
-  "dockerComposePath": "/opt/code/github/cloud-fe-components/cypress.docker-compose.yml",
-  "specsHomePath": "/opt/code/github/cloud-fe-components/tests/visual_testing/integration/",
-  "specsDockerPath": "tests/visual_testing/integration/",
+  "dockerComposePath": "/opt/code/github/design-system/cypress.docker-compose.yml",
+  "specsHomePath": "/opt/code/github/design-system/tests/cypress/storybook/",
+  "specsDockerPath": "tests/cypress/storybook/",
   "cypressContainerName": "cypress_container",
-  "mochawesomeJSONPath": "/opt/code/github/cloud-fe-components/tests/report/mochawesome-report/*.json",
+  "mochawesomeJSONPath": "/opt/code/github/design-system/tests/report/mochawesome-report/*.json",
   "reportPath": "./",
   "specs": [],
-  "analyseReport": false
+  "analyseReport": false,
+  "specsExecutionTimePath": "tests/specExecutionTime.json"
 }

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,0 +1,35 @@
+//@ts-check
+
+import fs from "fs";
+
+export function checkFileIsExisting(filePath) {
+  if (fs.existsSync(filePath)) {
+    return true;
+  } else {
+    console.log(
+      `report does not exist, are you sure there is a json report in ${filePath} path?`
+    );
+    return false;
+  }
+}
+
+export function parseJsonFile(filePath) {
+  if (checkFileIsExisting(filePath)) {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  }
+}
+
+export function orderBasedOnBrowserDuration(specs, browser) {
+    return specs.sort(function (a, b) {
+      let aDuration = a.data.find( item => item.browser === browser ).duration
+      let bDuration = b.data.find( item => item.browser === browser ).duration
+      return aDuration - bDuration;
+    });
+  }
+
+export function millisToMinutesAndSeconds(millis) {
+    let minutes = Math.floor(millis / 60000);
+    let seconds = ((millis % 60000) / 1000).toFixed(0);
+    return `${minutes}:${seconds < 10 ? "0" : ""}${seconds}`;
+  }
+  

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,6 +1,7 @@
 //@ts-check
 
 import fs from "fs";
+import path from "path";
 
 export function checkFileIsExisting(filePath) {
   if (fs.existsSync(filePath)) {
@@ -19,17 +20,21 @@ export function parseJsonFile(filePath) {
   }
 }
 
+export function writeJsonFile(data, outputDir, fileName) {
+  let _path = path.resolve(outputDir, fileName);
+  fs.writeFileSync(_path, JSON.stringify(data));
+}
+
 export function orderBasedOnBrowserDuration(specs, browser) {
-    return specs.sort(function (a, b) {
-      let aDuration = a.data.find( item => item.browser === browser ).duration
-      let bDuration = b.data.find( item => item.browser === browser ).duration
-      return aDuration - bDuration;
-    });
-  }
+  return specs.sort(function (a, b) {
+    let aDuration = a.data.find((item) => item.browser === browser).duration;
+    let bDuration = b.data.find((item) => item.browser === browser).duration;
+    return aDuration - bDuration;
+  });
+}
 
 export function millisToMinutesAndSeconds(millis) {
-    let minutes = Math.floor(millis / 60000);
-    let seconds = ((millis % 60000) / 1000).toFixed(0);
-    return `${minutes}:${seconds < 10 ? "0" : ""}${seconds}`;
-  }
-  
+  let minutes = Math.floor(millis / 60000);
+  let seconds = ((millis % 60000) / 1000).toFixed(0);
+  return `${minutes}:${seconds < 10 ? "0" : ""}${seconds}`;
+}

--- a/src/helper.js
+++ b/src/helper.js
@@ -21,8 +21,7 @@ export function parseJsonFile(filePath) {
 }
 
 export function writeJsonFile(data, outputDir, fileName) {
-  let _path = path.resolve(outputDir, fileName);
-  fs.writeFileSync(_path, JSON.stringify(data));
+  fs.writeFileSync(path.resolve(outputDir, fileName), JSON.stringify(data));
 }
 
 export function orderBasedOnBrowserDuration(specs, browser) {
@@ -34,7 +33,7 @@ export function orderBasedOnBrowserDuration(specs, browser) {
 }
 
 export function millisToMinutesAndSeconds(millis) {
-  let minutes = Math.floor(millis / 60000);
-  let seconds = ((millis % 60000) / 1000).toFixed(0);
+  const minutes = Math.floor(millis / 60000);
+  const seconds = ((millis % 60000) / 1000).toFixed(0);
   return `${minutes}:${seconds < 10 ? "0" : ""}${seconds}`;
 }

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -107,6 +107,14 @@ function getListOfSpecs(config, browser) {
   return specs;
 }
 
+function removeEmpty(arrays){
+  let results = [];
+  arrays.forEach(array => {
+    if (array.length > 0) results.push(array.filter(item => item !== ""));
+  })
+  return results;
+}
+
 function splitSpecsOverMachines(specs, config) {
   let noOfMachines = config.parallelizm * config.browsers.length;
   let specsForMachines = [];
@@ -123,7 +131,7 @@ function splitSpecsOverMachines(specs, config) {
     _cycles++;
   }
 
-  return specsForMachines;
+  return removeEmpty(specsForMachines);
 }
 
 
@@ -156,11 +164,11 @@ function generateSpecsCommandsOverMachinesOrederedByBrowsers(config) {
 
 
 function _constructCypressCommands(config) {
-  let noOfMachines = config.parallelizm * config.browsers.length;
   let bashCommands = [];
   let specsCommandsOverMachinesOrederedByBrowsers = generateSpecsCommandsOverMachinesOrederedByBrowsers(config);
+  let _noOfMachines = specsCommandsOverMachinesOrederedByBrowsers[config.browsers[0]].length;
 
-  for (let i=0; i<noOfMachines; i++){
+  for (let i=0; i<_noOfMachines; i++){
     let bashCommand = "exit_code=0";
 
     let _browsers = i%2 ? config.browsers: config.browsers.reverse();

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -61,8 +61,7 @@ function parseArgumentsIntoConfig(rawArgs) {
         .replace("[", "")
         .replace("]", "")
         .replace(", ", ",")
-        .replace(/"/g, "")
-        .replace(/'/g, "")
+        .replace(/"|'/g, "")
         .split(",");
     }
     result[key] = variable;
@@ -71,8 +70,8 @@ function parseArgumentsIntoConfig(rawArgs) {
 }
 
 function overWriteConfig(args) {
-  let configFile = args["--config"] || path.resolve(__dirname, "config.json");
-  let config = JSON.parse(fs.readFileSync(configFile, "utf-8"));
+  const configFile = args["--config"] || path.resolve(__dirname, "config.json");
+  const config = JSON.parse(fs.readFileSync(configFile, "utf-8"));
   return { ...config, ...args };
 }
 

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -163,7 +163,8 @@ function _constructCypressCommands(config) {
   for (let i=0; i<noOfMachines; i++){
     let bashCommand = "exit_code=0";
 
-    config.browsers.forEach((browser) => {
+    let _browsers = i%2 ? config.browsers: config.browsers.reverse();
+    _browsers.forEach((browser) => {
       bashCommand = `${bashCommand}; npx cypress run -b ${browser} --headless --spec ${specsCommandsOverMachinesOrederedByBrowsers[browser][i]} || exit_code=$? ; pkill -9 cypress`
     });
 

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -61,6 +61,8 @@ function parseArgumentsIntoConfig(rawArgs) {
         .replace("[", "")
         .replace("]", "")
         .replace(", ", ",")
+        .replace(/"/g, "")
+        .replace(/'/g, "")
         .split(",");
     }
     result[key] = variable;
@@ -90,7 +92,7 @@ function getListOfSpecs(config, browser) {
   let existingSpecs = [];
 
   if (config.specs.length > 0) {
-    existingSpecs = config.specs.map((item) => item.replace(/"/g, ""));
+    existingSpecs = config.specs
   } else {
     existingSpecs = sh.ls(config.specsHomePath);
   }

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -65,7 +65,7 @@ function parseArgumentsIntoConfig(rawArgs) {
 
 function overWriteConfig(args) {
   let configFile = args["--config"] || path.resolve(__dirname, "config.json");
-  let config = JSON.parse(fs.readFileSync(configFile));
+  let config = JSON.parse(fs.readFileSync(configFile, 'utf-8'));
   return { ...config, ...args };
 }
 
@@ -98,7 +98,7 @@ function getListOfSpecs(config, browser) {
     existingSpecs = sh.ls(config.specsHomePath);     
   }
 
-  let specsExecutionTime = JSON.parse(fs.readFileSync(config.specsExecutionTimePath));
+  let specsExecutionTime = JSON.parse(fs.readFileSync(config.specsExecutionTimePath, 'utf-8'));
   let browserSpecs = orderBasedOnBrowserDuration(specsExecutionTime, browser).map(item => item.specName);
   
   let specs = browserSpecs.filter(spec => existingSpecs.includes(spec));

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -90,7 +90,7 @@ function getListOfSpecs(config, browser) {
   let existingSpecs = [];
 
   if (config.specs.length > 0) {
-    existingSpecs = config.specs.map((item) => item.replaceAll('"', ""));
+    existingSpecs = config.specs.map((item) => item.replace(/"/g, ""));
   } else {
     existingSpecs = sh.ls(config.specsHomePath);
   }

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -124,6 +124,7 @@ function splitSpecsOverMachines(specs, config) {
   let _cycles = 0;
   while (specs.length > 0) {
     for (let i=0; i<noOfMachines; i++){
+      if (specs.length == 0) break;
       _cycles % 2 ? specsForMachines[i].push(specs.pop()) : specsForMachines[i].push(specs.shift());
     }
     _cycles++;


### PR DESCRIPTION
**Description**
- analysis of the execution time of each spec.
- Split specs depend on those numbers.

**Commands Example**
```bash
timeout --preserve-status 30m docker-compose -f tests/cypress.docker-compose.yml run --name container_12904__0 cypress-container bash -c 'exit_code=0; npx cypress run -b chrome --headless --spec cypress/storybook/list.js,cypress/storybook/picker.js,cypress/storybook/select.js,cypress/storybook/widgets.js,cypress/storybook/radio.js,cypress/storybook/table.js,cypress/storybook/badges.js,cypress/storybook/filters.js,cypress/storybook/snackbar.js,cypress/storybook/sort1.js,cypress/storybook/dialog.js,cypress/storybook/menu.js,cypress/storybook/circular.js,cypress/storybook/navigationDrawer.js,cypress/storybook/toolTip.js,cypress/storybook/stepper.js,cypress/storybook/textField.js,cypress/storybook/funcDateRangePicker.js,cypress/storybook/popover.js,cypress/storybook/form.js,cypress/storybook/funcDatePicker.js || exit_code=$? ; pkill -9 cypress; npx cypress run -b firefox --headless --spec cypress/storybook/list.js,cypress/storybook/picker.js,cypress/storybook/toggle.js,cypress/storybook/filters.js,cypress/storybook/avatar.js,cypress/storybook/funcDateRangeTimeRangePicker.js,cypress/storybook/breadcrumbs.js,cypress/storybook/sort1.js,cypress/storybook/snackbar.js,cypress/storybook/funcDateTimeRangePicker.js,cypress/storybook/toolTip.js,cypress/storybook/stepper.js,cypress/storybook/appBar.js,cypress/storybook/menu.js,cypress/storybook/textField.js,cypress/storybook/cards.js,cypress/storybook/popover.js,cypress/storybook/navigationDrawer.js,cypress/storybook/tabs.js,cypress/storybook/surface.js,cypress/storybook/alerts.js || exit_code=$? ; pkill -9 cypress ; exit $exit_code'
timeout --preserve-status 30m docker-compose -f tests/cypress.docker-compose.yml run --name container_23389__1 cypress-container bash -c 'exit_code=0; npx cypress run -b chrome --headless --spec cypress/storybook/checkbox.js,cypress/storybook/funcDateRangeTimeRangePicker.js,cypress/storybook/avatar.js,cypress/storybook/pageHeader.js,cypress/storybook/breadcrumbs.js,cypress/storybook/funcDateTimeRangePicker.js,cypress/storybook/toggle.js,cypress/storybook/errorPages.js,cypress/storybook/chip.js,cypress/storybook/sort2.js,cypress/storybook/helperText.js,cypress/storybook/cards.js,cypress/storybook/appBar.js,cypress/storybook/funcTimeRangePicker.js,cypress/storybook/button.js,cypress/storybook/funcDateTimePicker.js,cypress/storybook/funcTimePicker.js,cypress/storybook/alerts.js,cypress/storybook/tabs.js,cypress/storybook/surface.js,cypress/storybook/tiles.js || exit_code=$? ; pkill -9 cypress; npx cypress run -b firefox --headless --spec cypress/storybook/checkbox.js,cypress/storybook/errorPages.js,cypress/storybook/select.js,cypress/storybook/table.js,cypress/storybook/badges.js,cypress/storybook/funcDatePicker.js,cypress/storybook/radio.js,cypress/storybook/widgets.js,cypress/storybook/helperText.js,cypress/storybook/sort2.js,cypress/storybook/chip.js,cypress/storybook/funcDateRangePicker.js,cypress/storybook/button.js,cypress/storybook/funcDateTimePicker.js,cypress/storybook/funcTimePicker.js,cypress/storybook/form.js,cypress/storybook/circular.js,cypress/storybook/funcTimeRangePicker.js,cypress/storybook/tiles.js,cypress/storybook/pageHeader.js,cypress/storybook/dialog.js || exit_code=$? ; pkill -9 cypress ; exit $exit_code'

```