### PR TITLE
Nested directories for specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xislamtaha/orchestrator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "orchestrate cypress parallel execution across multiple Docker containers",
   "main": "src/orchestrator.js",
   "scripts": {

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -93,7 +93,7 @@ function getListOfSpecs(config, browser) {
   if (config.specs.length > 0) {
     existingSpecs = config.specs
   } else {
-    existingSpecs = sh.ls(config.specsHomePath);
+    existingSpecs = sh.ls('-R', config.specsHomePath).filter((val) => val.match(/.*ts|js/));
   }
 
   if (checkFileIsExisting(config.specsExecutionTimePath)) {


### PR DESCRIPTION
If the specs directory contains sub-directories then `sh.ls` won't consider that files and those specs won't be exeucted. 
Added the `-R` will recursively look for the files in the given directory and the filter will fetch only that matches `.js/.ts` files.  