### PR TITLE
release(2.0.1): enhance the log messages [DS-1275]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@0xislamtaha/orchestrator",
-  "version": "2.0.0",
-  "description": "orchestrate cypress parallel execution across multiple Docker containers",
+  "version": "2.0.1",
+  "description": "Execute cypress specs in parallel across multiple docker containers",
   "main": "src/orchestrator.js",
   "scripts": {
     "test": "echo \"No test specified\""
@@ -13,7 +13,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "author": "0xIslamTaha",
   "license": "MIT",
   "dependencies": {
     "arg": "^4.1.3",
@@ -26,5 +25,19 @@
   "files": [
     "bin/",
     "src/"
-  ]
+  ],
+  "keywords": [
+    "cypress",
+    "parallel execution",
+    "chrome",
+    "firefox",
+    "parallel",
+    "cypress parallel"
+  ],
+  "homepage": "https://github.com/0xIslamTaha/orchestrator",
+  "author": {
+    "name": "Islam Taha",
+    "email": "islamtaha2012@gmail.com",
+    "url": "https://twitter.com/0xIslamTaha"
+  }
 }

--- a/src/analyseReport.js
+++ b/src/analyseReport.js
@@ -7,6 +7,7 @@ import {
   writeJsonFile,
 } from "./helper.js";
 import path from "path";
+import * as lg from "./logger";
 
 
 const browsers = ["chrome", "firefox"];
@@ -43,8 +44,6 @@ function updateSpecData(suites, specName) {
 }
 
 export function analyseReport(mochaReportPath, executiontimeReportJsonPath) {
-  console.log("analyse the json report .... ");
-
   if (checkFileIsExisting(mochaReportPath)) {
     const executionTimeReportDir = path.dirname(executiontimeReportJsonPath);
     const executionTimeReporJson = executiontimeReportJsonPath.split("/").pop();
@@ -61,9 +60,7 @@ export function analyseReport(mochaReportPath, executiontimeReportJsonPath) {
     writeJsonFile(specs, executionTimeReportDir, executionTimeReporJson);
 
     for (let browser of browsers) {
-      console.log(
-        `------------------------- ${browser} -------------------------`
-      ); 
+      lg.subStep(`${browser}`);
       let data = orderBasedOnBrowserDuration(specs, browser).map((spec) => {
         return {
           specName: spec.specName,

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,30 @@
+function banner() {
+  let banner = `
+   ██████      ██████       ██████     ██   ██     ███████     ███████     ████████     ██████       █████      ████████      ██████      ██████  
+  ██    ██     ██   ██     ██          ██   ██     ██          ██             ██        ██   ██     ██   ██        ██        ██    ██     ██   ██ 
+  ██    ██     ██████      ██          ███████     █████       ███████        ██        ██████      ███████        ██        ██    ██     ██████  
+  ██    ██     ██   ██     ██          ██   ██     ██               ██        ██        ██   ██     ██   ██        ██        ██    ██     ██   ██ 
+   ██████      ██   ██      ██████     ██   ██     ███████     ███████        ██        ██   ██     ██   ██        ██         ██████      ██   ██ 
+                                                                                                                             v 2.0.1 @0xIslamTaha                                                                                                                                                                                                                                                                                
+`;
+
+  console.log(banner);
+}
+
+
+function step(msg, newLine=false) {
+  let message;
+  if (newLine) {
+    message = `\n[*] ${msg}`; 
+  } else {
+    message = `[*] ${msg}`;
+  }
+  console.log(message);
+}
+
+function subStep(subStep){
+    let message = `[-] ${subStep}`;
+    console.log(message);
+}
+
+export { banner, step, subStep };


### PR DESCRIPTION
**Description**
Enhance the log messages. 

**Logs**
```bash
╭─islamtaha@RLYLTPZ175 /opt/code/github/orchestrator-public-use-case  ‹2.0.1*› 
╰─➤  npx orchestrator --config orchestrator.json 

   ██████      ██████       ██████     ██   ██     ███████     ███████     ████████     ██████       █████      ████████      ██████      ██████  
  ██    ██     ██   ██     ██          ██   ██     ██          ██             ██        ██   ██     ██   ██        ██        ██    ██     ██   ██ 
  ██    ██     ██████      ██          ███████     █████       ███████        ██        ██████      ███████        ██        ██    ██     ██████  
  ██    ██     ██   ██     ██          ██   ██     ██               ██        ██        ██   ██     ██   ██        ██        ██    ██     ██   ██ 
   ██████      ██   ██      ██████     ██   ██     ███████     ███████        ██        ██   ██     ██   ██        ██         ██████      ██   ██ 
                                                                                                                             v 2.0.1 @0xIslamTaha                                                                                                                                                                                                                                                                                

[*] Overwrite the config file with the arguments if there is any
[*] Export the environment variables

[*] Execute the pre commands
[-] ~$ echo 'START ORCHESTRATOR'
START ORCHESTRATOR
[-] ~$ rm -rf cypress/report/* #Remove the old reports
[-] ~$ mkdir -p mochawesome-report

[*] Start the cypress containers
[-] ~$ timeout --preserve-status 30m docker-compose -f docker-compose.yml run --name container_5995__0 cypress-container bash -c 'exit_code=0; npx cypress run -b chrome --headless --spec cypress/integration/examples/location.spec.js,cypress/integration/examples/actions.spec.js,cypress/integration/examples/local_storage.spec.js,cypress/integration/examples/network_requests.spec.js,cypress/integration/examples/files.spec.js,cypress/integration/examples/waiting.spec.js,cypress/integration/examples/querying.spec.js,cypress/integration/examples/assertions.spec.js,cypress/integration/examples/viewport.spec.js,cypress/integration/examples/spies_stubs_clocks.spec.js || exit_code=$? ; pkill -9 cypress ; exit $exit_code'
[-] ~$ timeout --preserve-status 30m docker-compose -f docker-compose.yml run --name container_89492__1 cypress-container bash -c 'exit_code=0; npx cypress run -b chrome --headless --spec cypress/integration/examples/window.spec.js,cypress/integration/examples/navigation.spec.js,cypress/integration/examples/cookies.spec.js,cypress/integration/examples/traversal.spec.js,cypress/integration/examples/connectors.spec.js,cypress/integration/examples/aliasing.spec.js,cypress/integration/examples/cypress_api.spec.js,cypress/integration/examples/misc.spec.js,cypress/integration/examples/utilities.spec.js || exit_code=$? ; pkill -9 cypress ; exit $exit_code'
Creating orchestrator-public-use-case_cypress-container_run ... 
Creating orchestrator-public-use-case_cypress-container_run ... done
[32:0119/175921.513363:ERROR:bus.cc(392)] Failed to connect to the bus: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory
[32:0119/175921.513224:ERROR:bus.cc(392)] Failed to connect to the bus: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory
[32:0119/175921.514695:ERROR:bus.cc(392)] Failed to connect to the bus: Address does not contain a colon
[32:0119/175921.514721:ERROR:bus.cc(392)] Failed to connect to the bus: Address does not contain a colon
[32:0119/175921.514718:ERROR:bus.cc(392)] Failed to connect to the bus: Address does not contain a colon
[32:0119/175921.514743:ERROR:bus.cc(392)] Failed to connect to the bus: Address does not contain a colon
[206:0119/175921.522840:ERROR:gpu_init.cc(453)] Passthrough is not supported, GL is swiftshader, ANGLE is 
[204:0119/175921.544664:ERROR:gpu_init.cc(453)] Passthrough is not supported, GL is swiftshader, ANGLE is 
The `firefoxGcInterval` configuration option was removed in Cypress version `8.0.0`. It was introduced to work around a bug in Firefox 79 and below.

Since Cypress no longer supports Firefox 85 and below in Cypress 8, this option was removed.

You can safely remove this option from your config.
The `firefoxGcInterval` configuration option was removed in Cypress version `8.0.0`. It was introduced to work around a bug in Firefox 79 and below.

Since Cypress no longer supports Firefox 85 and below in Cypress 8, this option was removed.

You can safely remove this option from your config.

====================================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        9.1.1                                                                          │
  │ Browser:        Chrome 94 (headless)                                                           │
  │ Node Version:   v16.5.0 (/usr/local/bin/node)                                                  │
  │ Specs:          9 found (examples/aliasing.spec.js, examples/connectors.spec.js, examples/cook │
  │                 ies.spec.js, examples/cypress_api.spec.js, examples/misc.spec.js, examples/nav │
  │                 igation.spec.js, examples/traversal.spec.js, examples/utilities.spec.js, examp │
  │                 les/window.spec.js)                                                            │
  │ Searched:       cypress/integration/examples/window.spec.js, cypress/integration/examples/navi │
  │                 gation.spec.js, cypress/integration/examples/cookies.spec.js, cypress/integrat │
  │                 ion/examples/traversal.spec.js, cypress/integration/examples/connectors.spec.j │
  │                 s, cypress/integration/examples/aliasing.spec.js, cypress/integration/examples │
  │                 /cypress_api.spec.js, cypress/integration/examples/misc.spec.js, cypress/integ │
  │                 ration/examples/utilities.spec.js                                              │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/aliasing.spec.js                                                       (1 of 9)

====================================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        9.1.1                                                                          │
  │ Browser:        Chrome 94 (headless)                                                           │
  │ Node Version:   v16.5.0 (/usr/local/bin/node)                                                  │
  │ Specs:          10 found (examples/actions.spec.js, examples/assertions.spec.js, examples/file │
  │                 s.spec.js, examples/local_storage.spec.js, examples/location.spec.js, examples │
  │                 /network_requests.spec.js, examples/querying.spec.js, examples/spies_stubs_clo │
  │                 cks.spec.js, examples/v...)                                                    │
  │ Searched:       cypress/integration/examples/location.spec.js, cypress/integration/examples/ac │
  │                 tions.spec.js, cypress/integration/examples/local_storage.spec.js, cypress/int │
  │                 egration/examples/network_requests.spec.js, cypress/integration/examples/files │
  │                 .spec.js, cypress/integration/examples/waiting.spec.js, cypress/integration/ex │
  │                 amples/querying.spec.js, cypress/integration/examples/assertions.spec.js, cypr │
  │                 ess/integration/examples/viewport.spec.js, cypress/integration/examples/spies_ │
  │                 stubs_clocks.spec.js                                                           │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/actions.spec.js                                                       (1 of 10)
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating


  Aliasing


  Actions
    ✓ .as() - alias a DOM element for later use
    ✓ .as() - alias a route for later use


  2 passing (11s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        2                                                                                │
  │ Passing:      2                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     11 seconds                                                                       │
  │ Spec Ran:     examples/aliasing.spec.js                                                        │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/connectors.spec.js                                                     (2 of 9)


  Connectors
    ✓ .type() - type into a DOM element (8496ms)
    ✓ .focus() - focus on a DOM element
    ✓ .blur() - blur off a DOM element
    ✓ .each() - iterate over an array of elements
    ✓ .clear() - clears an input or textarea element
    ✓ .its() - get properties on the current subject
    ✓ .submit() - submit a form
    ✓ .invoke() - invoke a function on the current subject
    ✓ .spread() - spread an array as individual args to callback function
    .then()
    ✓ .click() - click on a DOM element
    ✓ .dblclick() - double click on a DOM element
      ✓ invokes a callback function with the current subject (5503ms)
    ✓ .rightclick() - right click on a DOM element
      ✓ yields the returned value to the next command
    ✓ .check() - check a checkbox or radio element
    ✓ .uncheck() - uncheck a checkbox element
      ✓ yields the original subject without return
      ✓ yields the value yielded by the last Cypress command inside


  8 passing (19s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome_001.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        8                                                                                │
  │ Passing:      8                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     18 seconds                                                                       │
  │ Spec Ran:     examples/connectors.spec.js                                                      │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/cookies.spec.js                                                        (3 of 9)
    ✓ .select() - select an option in a <select> element
    ✓ .scrollIntoView() - scroll an element into view


  Cookies
    ✓ .trigger() - trigger an event on a DOM element
    ✓ cy.scrollTo() - scroll the window or element to a position


  14 passing (35s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome_002.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        14                                                                               │
  │ Passing:      14                                                                               │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     35 seconds                                                                       │
  │ Spec Ran:     examples/actions.spec.js                                                         │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/assertions.spec.js                                                    (2 of 10)


  Assertions
    Implicit Assertions
      ✓ .should() - make an assertion about the current subject
    ✓ cy.getCookie() - get a browser cookie
      ✓ .and() - chain multiple assertions together
    Explicit Assertions
      ✓ expect - make an assertion about a specified subject
    ✓ cy.getCookies() - get browser cookies
      ✓ pass your own callback function to should()
    ✓ cy.setCookie() - set a browser cookie
      ✓ finds element by class name regex
      ✓ can throw any error
    ✓ cy.clearCookie() - clear a browser cookie
      ✓ matches unknown text between two elements
    ✓ cy.clearCookies() - clear browser cookies


  5 passing (7s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome_003.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        5                                                                                │
  │ Passing:      5                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     6 seconds                                                                        │
  │ Spec Ran:     examples/cookies.spec.js                                                         │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/cypress_api.spec.js                                                    (4 of 9)
      ✓ assert - assert shape of an object


  Cypress.Commands
      ✓ retries the should callback until assertions pass


  9 passing (5s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome_004.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        9                                                                                │
  │ Passing:      9                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     4 seconds                                                                        │
  │ Spec Ran:     examples/assertions.spec.js                                                      │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/files.spec.js                                                         (3 of 10)
    ✓ .add() - create a custom command

  Cypress.Cookies
    ✓ .debug() - enable or disable debugging
    ✓ .preserveOnce() - preserve cookies by key
    ✓ .defaults() - set defaults for all cookies

  Cypress.arch
    ✓ Get CPU architecture name of underlying OS

  Cypress.config()
    ✓ Get and set configuration options

  Cypress.dom
    ✓ .isHidden() - determine if a DOM element is hidden

  Cypress.env()
    ✓ Get environment variables

  Cypress.log
    ✓ Control what is printed to the Command Log

  Cypress.platform


  Files
    ✓ Get underlying OS name

  Cypress.version
    ✓ Get current version of Cypress being run

  Cypress.spec
    ✓ Get current spec information


  12 passing (5s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome_005.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        12                                                                               │
  │ Passing:      12                                                                               │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     4 seconds                                                                        │
  │ Spec Ran:     examples/cypress_api.spec.js                                                     │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/misc.spec.js                                                           (5 of 9)


  Misc
    ✓ cy.fixture() - load a fixture
    ✓ cy.fixture() or require - load a fixture
    ✓ cy.readFile() - read file contents
    ✓ cy.writeFile() - write to a file


  4 passing (5s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome_006.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        4                                                                                │
  │ Passing:      4                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     5 seconds                                                                        │
  │ Spec Ran:     examples/files.spec.js                                                           │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/local_storage.spec.js                                                 (4 of 10)


  Local Storage
    ✓ .end() - end the command chain
    ✓ cy.exec() - execute a system command
    ✓ cy.focused() - get the DOM element that has focus
    ✓ cy.wrap() - wrap an object
    Cypress.Screenshot
    ✓ cy.clearLocalStorage() - clear all data in local storage


  1 passing (3s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome_007.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        1                                                                                │
  │ Passing:      1                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     2 seconds                                                                        │
  │ Spec Ran:     examples/local_storage.spec.js                                                   │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/location.spec.js                                                      (5 of 10)


  Location
      ✓ cy.screenshot() - take a screenshot
      ✓ Cypress.Screenshot.defaults() - change default config of screenshots


  6 passing (9s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome_008.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        6                                                                                │
  │ Passing:      6                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  1                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     8 seconds                                                                        │
  │ Spec Ran:     examples/misc.spec.js                                                            │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


  (Screenshots)

  -  /cypress_testing/cypress/screenshots/examples/misc.spec.js/my-image.png             (1000x1800)


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/navigation.spec.js                                                     (6 of 9)


  Navigation
    ✓ cy.hash() - get the current URL hash
    ✓ cy.location() - get window.location
    ✓ cy.url() - get the current URL


  3 passing (4s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome_009.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        3                                                                                │
  │ Passing:      3                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     3 seconds                                                                        │
  │ Spec Ran:     examples/location.spec.js                                                        │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/network_requests.spec.js                                              (6 of 10)


  Network Requests
    ✓ cy.go() - go back or forward in the browser's history
    ✓ cy.request() - make an XHR request
    ✓ cy.request() - verify response using BDD syntax
    ✓ cy.reload() - reload the page
    ✓ cy.request() with query parameters
    ✓ cy.visit() - visit a remote url


  3 passing (8s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome_010.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        3                                                                                │
  │ Passing:      3                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     7 seconds                                                                        │
  │ Spec Ran:     examples/navigation.spec.js                                                      │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/traversal.spec.js                                                      (7 of 9)
    ✓ cy.request() - pass result to the second request


  Traversal
    ✓ cy.request() - save response in the shared test context
    ✓ cy.intercept() - route responses to matching requests


  6 passing (8s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome_011.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        6                                                                                │
  │ Passing:      6                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     7 seconds                                                                        │
  │ Spec Ran:     examples/network_requests.spec.js                                                │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/querying.spec.js                                                      (7 of 10)
    ✓ .children() - get child DOM elements
    ✓ .closest() - get closest ancestor DOM element
    ✓ .eq() - get a DOM element at a specific index
    ✓ .filter() - get DOM elements that match the selector
    ✓ .find() - get descendant DOM elements of the selector


  Querying
    ✓ .first() - get first DOM element
    ✓ .last() - get last DOM element
    ✓ .next() - get next sibling DOM element
    ✓ .nextAll() - get all next sibling DOM elements
    ✓ .nextUntil() - get next sibling DOM elements until next el
    ✓ .not() - remove DOM elements from set of DOM elements
    ✓ .parent() - get parent DOM element from DOM elements
    ✓ .parents() - get parent DOM elements from DOM elements
    ✓ cy.get() - query DOM elements
    ✓ .parentsUntil() - get parent DOM elements from DOM elements until el
    ✓ .prev() - get previous sibling DOM element
    ✓ cy.contains() - query DOM elements with matching content
    ✓ .prevAll() - get all previous sibling DOM elements
    ✓ .within() - query DOM elements within a specific element
    ✓ .prevUntil() - get all previous sibling DOM elements until el
    ✓ cy.root() - query the root DOM element
    ✓ .siblings() - get all sibling DOM elements


  18 passing (6s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome_012.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        18                                                                               │
  │ Passing:      18                                                                               │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     6 seconds                                                                        │
  │ Spec Ran:     examples/traversal.spec.js                                                       │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/utilities.spec.js                                                      (8 of 9)
    ✓ best practices - selecting elements


  5 passing (4s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome_013.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        5                                                                                │
  │ Passing:      5                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     3 seconds                                                                        │
  │ Spec Ran:     examples/querying.spec.js                                                        │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/spies_stubs_clocks.spec.js                                            (8 of 10)


  Utilities


  Spies, Stubs, and Clock
    ✓ Cypress._ - call a lodash method
    ✓ cy.spy() - wrap a method in a spy
    ✓ Cypress.$ - call a jQuery method
    ✓ Cypress.Blob - blob utilities and base64 string conversion
    ✓ Cypress.minimatch - test out glob patterns against strings
    ✓ Cypress.Promise - instantiate a bluebird promise


  5 passing (4s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome_014.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        5                                                                                │
  │ Passing:      5                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     4 seconds                                                                        │
  │ Spec Ran:     examples/utilities.spec.js                                                       │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/window.spec.js                                                         (9 of 9)
    ✓ cy.spy() retries until assertions pass
    ✓ cy.stub() - create a stub and/or replace a function with stub
    ✓ cy.clock() - control time in the browser


  Window
    ✓ cy.tick() - move time in the browser
    ✓ cy.stub() matches depending on arguments
    ✓ matches call arguments using Sinon matchers


  7 passing (5s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome_015.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        7                                                                                │
  │ Passing:      7                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     5 seconds                                                                        │
  │ Spec Ran:     examples/spies_stubs_clocks.spec.js                                              │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/viewport.spec.js                                                      (9 of 10)


  Viewport
    ✓ cy.window() - get the global window object
    ✓ cy.document() - get the document object
    ✓ cy.title() - get the title


  3 passing (2s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome_016.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        3                                                                                │
  │ Passing:      3                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     1 second                                                                         │
  │ Spec Ran:     examples/window.spec.js                                                          │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  examples/aliasing.spec.js                00:11        2        2        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  examples/connectors.spec.js              00:18        8        8        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  examples/cookies.spec.js                 00:06        5        5        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  examples/cypress_api.spec.js             00:04       12       12        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  examples/misc.spec.js                    00:08        6        6        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  examples/navigation.spec.js              00:07        3        3        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  examples/traversal.spec.js               00:06       18       18        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  examples/utilities.spec.js               00:04        5        5        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  examples/window.spec.js                  00:01        3        3        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        01:10       62       62        -        -        -  

    ✓ cy.viewport() - set the viewport size and dimension


  1 passing (5s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome_017.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        1                                                                                │
  │ Passing:      1                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     4 seconds                                                                        │
  │ Spec Ran:     examples/viewport.spec.js                                                        │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  examples/waiting.spec.js                                                      (10 of 10)


  Waiting
    ✓ cy.wait() - wait for a specific amount of time (5443ms)
    ✓ cy.wait() - wait for a specific route


  2 passing (7s)

[mochawesome] Report JSON saved to /cypress_testing/cypress/report/mochawesome-report/mochawesome_018.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        2                                                                                │
  │ Passing:      2                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     7 seconds                                                                        │
  │ Spec Ran:     examples/waiting.spec.js                                                         │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  examples/actions.spec.js                 00:35       14       14        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  examples/assertions.spec.js              00:04        9        9        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  examples/files.spec.js                   00:05        4        4        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  examples/local_storage.spec.js           00:02        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  examples/location.spec.js                00:03        3        3        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  examples/network_requests.spec.js        00:07        6        6        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  examples/querying.spec.js                00:03        5        5        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  examples/spies_stubs_clocks.spec.js      00:05        7        7        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  examples/viewport.spec.js                00:04        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  examples/waiting.spec.js                 00:07        2        2        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        01:20       52       52        -        -        -  


[*] Stop the cypress containers
Removing container_89492__1 ... done
Removing container_5995__0  ... done

[*] Generate the reports
[-] HTML report: mochawesome-report/mochawsome.html
[-] Execution time report: executionTimeReprot/specsExecutionTime.json
[-] chrome
┌─────────┬──────────────────────────────┬──────────┐
│ (index) │           specName           │ duration │
├─────────┼──────────────────────────────┼──────────┤
│    0    │       'window.spec.js'       │  '0:02'  │
│    1    │      'location.spec.js'      │  '0:02'  │
│    2    │   'local_storage.spec.js'    │  '0:03'  │
│    3    │      'cookies.spec.js'       │  '0:04'  │
│    4    │     'connectors.spec.js'     │  '0:04'  │
│    5    │       'files.spec.js'        │  '0:05'  │
│    6    │      'querying.spec.js'      │  '0:05'  │
│    7    │    'cypress_api.spec.js'     │  '0:06'  │
│    8    │      'viewport.spec.js'      │  '0:07'  │
│    9    │     'utilities.spec.js'      │  '0:07'  │
│   10    │        'misc.spec.js'        │  '0:08'  │
│   11    │      'aliasing.spec.js'      │  '0:08'  │
│   12    │ 'spies_stubs_clocks.spec.js' │  '0:08'  │
│   13    │     'assertions.spec.js'     │  '0:08'  │
│   14    │     'traversal.spec.js'      │  '0:10'  │
│   15    │     'navigation.spec.js'     │  '0:10'  │
│   16    │      'waiting.spec.js'       │  '0:12'  │
│   17    │  'network_requests.spec.js'  │  '0:12'  │
│   18    │      'actions.spec.js'       │  '0:37'  │
└─────────┴──────────────────────────────┴──────────┘
[-] firefox
┌─────────┬──────────────────────────────┬──────────┐
│ (index) │           specName           │ duration │
├─────────┼──────────────────────────────┼──────────┤
│    0    │       'window.spec.js'       │  '0:00'  │
│    1    │      'location.spec.js'      │  '0:00'  │
│    2    │   'local_storage.spec.js'    │  '0:00'  │
│    3    │      'cookies.spec.js'       │  '0:00'  │
│    4    │     'connectors.spec.js'     │  '0:00'  │
│    5    │       'files.spec.js'        │  '0:00'  │
│    6    │      'querying.spec.js'      │  '0:00'  │
│    7    │    'cypress_api.spec.js'     │  '0:00'  │
│    8    │      'viewport.spec.js'      │  '0:00'  │
│    9    │     'utilities.spec.js'      │  '0:00'  │
│   10    │        'misc.spec.js'        │  '0:00'  │
│   11    │      'aliasing.spec.js'      │  '0:00'  │
│   12    │ 'spies_stubs_clocks.spec.js' │  '0:00'  │
│   13    │     'assertions.spec.js'     │  '0:00'  │
│   14    │     'traversal.spec.js'      │  '0:00'  │
│   15    │     'navigation.spec.js'     │  '0:00'  │
│   16    │      'waiting.spec.js'       │  '0:00'  │
│   17    │  'network_requests.spec.js'  │  '0:00'  │
│   18    │      'actions.spec.js'       │  '0:00'  │
└─────────┴──────────────────────────────┴──────────┘

[*] Total execution time: 1:38.297 (m:ss.mmm)

```